### PR TITLE
Update Node dependency to newer version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MultilineStrings = "1e8d2bf6-9821-4900-9a2f-4d87552df2bd"
-NodeJS_16_jll = "a4b94fbf-73f5-58ff-888d-48a8396e17f6"
+NodeJS_18_jll = "c1e1d063-8311-5f52-a749-c7b05e91ae37"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/Deneb.jl
+++ b/src/Deneb.jl
@@ -1,7 +1,7 @@
 module Deneb
 
 using UUIDs
-using NodeJS_16_jll
+using NodeJS_18_jll
 using JSON, Tables
 using MultilineStrings: indent
 


### PR DESCRIPTION
This addresses the npm version [issue](https://github.com/brucala/Deneb.jl/issues/3) and updates the Project.toml and src/Deneb.jl to use the NodeJS_18 binary builder [recipe in Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil/tree/master/N/NodeJS). See [this issue](https://github.com/JuliaPackaging/Yggdrasil/pull/6598).

I have tested the changes locally in the dev directory housing Deneb. All tests passed; see below in expandable section. The dev package was also used in another project. Only one issue was identified: the user may need to  `rm -rf ~/.npm` installed by the earlier version (NodeJS_16_jll). Otherwise, the user may receive an error: `Error: CanvasRenderer is missing a valid canvas or context`. See stack overflow [post](https://stackoverflow.com/questions/64556990/altair-library-difficulty-to-save-a-chart-in-png-getting-a-js-error).


<details>
<summary>test summary</summary>

```
julia> versioninfo()
Julia Version 1.9.2
Commit e4ee485e90 (2023-07-05 09:39 UTC)
Platform Info:
  OS: macOS (arm64-apple-darwin21.6.0)
  CPU: 10 × Apple M1 Max
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, apple-m1)
  Threads: 5 on 8 virtual cores
Environment:
  JULIA_NUM_THREADS = 4
  JULIA_EDITOR = Emacs
  JULIA_PKG_DEVDIR = /Users/foo/Documents/julia/dev
  JULIA_USE_NEW_PARSER = 0

(Deneb) pkg> test
    Updating registry at `~/.julia/registries/General.toml`
    Updating `~/Documents/julia/dev/Deneb.jl/Project.toml`
  [682c06a0] + JSON v0.21.4
  [1e8d2bf6] + MultilineStrings v0.1.1
  [bd369af6] + Tables v1.10.1
  [c1e1d063] + NodeJS_18_jll v18.16.0+0
    Updating `~/Documents/julia/dev/Deneb.jl/Manifest.toml`
  [9a962f9c] + DataAPI v1.15.0
  [e2d170a0] + DataValueInterfaces v1.0.0
  [82899510] + IteratorInterfaceExtensions v1.0.0
  [692b3bcd] + JLLWrappers v1.4.1
  [682c06a0] + JSON v0.21.4
  [1e8d2bf6] + MultilineStrings v0.1.1
  [bac558e1] + OrderedCollections v1.6.0
  [69de0a69] + Parsers v2.7.1
  [aea7be01] + PrecompileTools v1.1.2
  [21216c6a] + Preferences v1.4.0
  [3783bdb8] + TableTraits v1.0.1
  [bd369af6] + Tables v1.10.1
  [c1e1d063] + NodeJS_18_jll v18.16.0+0
  [56f22d72] + Artifacts
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [b77e0a4c] + InteractiveUtils
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [de0858da] + Printf
  [9a3f8284] + Random
  [ea8e919c] + SHA v0.7.0
  [9e88b42a] + Serialization
  [fa267f1f] + TOML v1.0.3
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
  [e66e0078] + CompilerSupportLibraries_jll v1.0.5+0
  [4536629a] + OpenBLAS_jll v0.3.21+4
  [8e850b90] + libblastrampoline_jll v5.8.0+0
     Testing Deneb
      Status `/private/var/folders/mh/d010xh0j5ss8yws8rknh568c0000gn/T/jl_KsOwBg/Project.toml`
  [b5a61f88] Deneb v0.1.0 `~/Documents/julia/dev/Deneb.jl`
  [8dfed614] Test `@stdlib/Test`
      Status `/private/var/folders/mh/d010xh0j5ss8yws8rknh568c0000gn/T/jl_KsOwBg/Manifest.toml`
  [9a962f9c] DataAPI v1.15.0
  [e2d170a0] DataValueInterfaces v1.0.0
  [b5a61f88] Deneb v0.1.0 `~/Documents/julia/dev/Deneb.jl`
  [82899510] IteratorInterfaceExtensions v1.0.0
  [692b3bcd] JLLWrappers v1.4.1
  [682c06a0] JSON v0.21.4
  [1e8d2bf6] MultilineStrings v0.1.1
  [bac558e1] OrderedCollections v1.6.0
  [69de0a69] Parsers v2.7.1
  [aea7be01] PrecompileTools v1.1.2
  [21216c6a] Preferences v1.4.0
  [3783bdb8] TableTraits v1.0.1
  [bd369af6] Tables v1.10.1
  [c1e1d063] NodeJS_18_jll v18.16.0+0
  [56f22d72] Artifacts `@stdlib/Artifacts`
  [2a0f44e3] Base64 `@stdlib/Base64`
  [ade2ca70] Dates `@stdlib/Dates`
  [b77e0a4c] InteractiveUtils `@stdlib/InteractiveUtils`
  [8f399da3] Libdl `@stdlib/Libdl`
  [37e2e46d] LinearAlgebra `@stdlib/LinearAlgebra`
  [56ddb016] Logging `@stdlib/Logging`
  [d6f4376e] Markdown `@stdlib/Markdown`
  [a63ad114] Mmap `@stdlib/Mmap`
  [de0858da] Printf `@stdlib/Printf`
  [9a3f8284] Random `@stdlib/Random`
  [ea8e919c] SHA v0.7.0 `@stdlib/SHA`
  [9e88b42a] Serialization `@stdlib/Serialization`
  [fa267f1f] TOML v1.0.3 `@stdlib/TOML`
  [8dfed614] Test `@stdlib/Test`
  [cf7118a7] UUIDs `@stdlib/UUIDs`
  [4ec0a83e] Unicode `@stdlib/Unicode`
  [e66e0078] CompilerSupportLibraries_jll v1.0.5+0 `@stdlib/CompilerSupportLibraries_jll`
  [4536629a] OpenBLAS_jll v0.3.21+4 `@stdlib/OpenBLAS_jll`
  [8e850b90] libblastrampoline_jll v5.8.0+0 `@stdlib/libblastrampoline_jll`
Precompiling project...
  15 dependencies successfully precompiled in 15 seconds
     Testing Running tests...
Test Summary:  | Pass  Total   Time
Deneb.jl tests |  269    269  14.1s
     Testing Deneb tests passed
```
  
</details>